### PR TITLE
Slider updates beat on mouse release instead of on each increment

### DIFF
--- a/metronome.js
+++ b/metronome.js
@@ -48,12 +48,14 @@
     });
 
     elements.beatType.addEventListener('input', update);
-    
+
+    // tempo: update display value while dragged and update beat when release
+    elements.tempo.addEventListener('input', updateTempoValue);
+    elements.tempo.addEventListener('mouseup', update);
+
     elements.closeOptions.addEventListener('click', (e) => {
         elements.options.classList.toggle('hidden');
-    });
-
-    elements.tempo.addEventListener('input', update);		
+    });	
 
     function updateTempoValue() {
         elements.tempoValue.innerText = `at ${elements.tempo.value} bpm`;


### PR DESCRIPTION
At the moment, dragging the tempo slider while beat is playing produces the quickly repeated beats due to the beat updating on each value change. I changed this behavior to only update the displayed value while holding down the slider and update the actual beat when slider is released (mouseup). I feel like this should be the better behavior.