### PR TITLE
Fix broken onInput event listener

### DIFF
--- a/metronome.js
+++ b/metronome.js
@@ -54,7 +54,9 @@ elements.closeOptions.addEventListener('click', (e) => {
     elements.options.classList.toggle('hidden');
 });
 
-var updateTempoValue = () => elements.tempoValue.innerText = `at ${elements.tempo.value} bpm`;
+function updateTempoValue() {
+    elements.tempoValue.innerText = `at ${elements.tempo.value} bpm`;
+}
 
 function togglePlay() {
     settings.playSound = !settings.playSound;


### PR DESCRIPTION
Sliding the bpm slider no longer updated the displayed tempo.

The event listener responsible for this was broken because of a refactored function. This reverts the lambda back to a regular function.