### PR TITLE
Fixed sound overlap on Edge

### DIFF
--- a/metronome.js
+++ b/metronome.js
@@ -147,6 +147,7 @@ function tick() {
     }
 
     oscillator.start();
+    oscillator.stop(context.currentTime + 0.1);
 
     if (gain.gain.value > 0) {
         gain.gain.exponentialRampToValueAtTime(0.00001, context.currentTime + .10)


### PR DESCRIPTION
Add a fixed sound duration to prevent overlapping sound on Edge. Uses the same sound duration as Firefox (0.1 seconds). This fix doesn't affect Chrome since the default sound duration in Chrome is less than 0.1 seconds.
Fixes issue #21